### PR TITLE
Faster xdr reader

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Carlos Ramos Carreño
-Copyright (c) 2023 CSC - IT Center for Science Ltd.
+Copyright (c) 2018 Rdata developers.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2018 Carlos Ramos Carreño
+Copyright (c) 2023 CSC - IT Center for Science Ltd.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,10 @@ keywords = [
 	"r",
 	"dataset",
 ]
+authors = [
+  {name = "Carlos Ramos Carreño", email = "vnmabus@gmail.com"},
+  {name = "Tuomas Rossi", email = "tuomas.rossi@csc.fi"},
+]
 maintainers = [
   {name = "Carlos Ramos Carreño", email = "vnmabus@gmail.com"},
 ]

--- a/rdata/io/xdr.py
+++ b/rdata/io/xdr.py
@@ -49,7 +49,7 @@ class ParserXDR(Parser):
         itemtype = f'{itemkind}{itemsize}'
         buffer = self.file.read(length * itemsize)
         # Read in big-endian order and convert to native byte order
-        return np.frombuffer(buffer, dtype=f'>{itemtype}').astype(f'={itemtype}')
+        return np.frombuffer(buffer, dtype=f'>{itemtype}').astype(f'={itemtype}', copy=False)
 
     def parse_int(self) -> int:  # noqa: D102
         return int(self._parse_array('i', 4, length=1)[0])

--- a/rdata/io/xdr.py
+++ b/rdata/io/xdr.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import (
+    Any,
+    BinaryIO,
+)
+
+import numpy as np
+import numpy.typing as npt
+
+from rdata.parser._parser import (
+    AltRepConstructorMap,
+    DEFAULT_ALTREP_MAP,
+    Parser,
+    RData,
+)
+
+
+
+R_INT_NA = -2**31  # noqa: WPS432
+"""Value used to represent a missing integer in R."""
+
+
+class ParserXDR(Parser):
+    """Parser used when the integers and doubles are in XDR format."""
+
+    def __init__(
+        self,
+        file: BinaryIO,
+        *,
+        expand_altrep: bool = True,
+        altrep_constructor_dict: AltRepConstructorMap = DEFAULT_ALTREP_MAP,
+    ) -> None:
+        super().__init__(
+            expand_altrep=expand_altrep,
+            altrep_constructor_dict=altrep_constructor_dict,
+        )
+        self.file = file
+
+    def _parse_array(self,
+                     itemkind: str,
+                     itemsize: int,
+                     *,
+                     length: int | None = None,
+    ) -> npt.NDArray[Any]:  # noqa: D102
+        if length is None:
+            length = self.parse_int()
+
+        itemtype = f'{itemkind}{itemsize}'
+        buffer = self.file.read(length * itemsize)
+        # Read in big-endian order and convert to native byte order
+        return np.frombuffer(buffer, dtype=f'>{itemtype}').astype(f'={itemtype}')
+
+    def parse_int(self) -> int:  # noqa: D102
+        return int(self._parse_array('i', 4, length=1)[0])
+
+    def parse_double(self) -> float:  # noqa: D102
+        return float(self._parse_array('f', 8, length=1)[0])
+
+    def parse_complex(self) -> complex:  # noqa: D102
+        return complex(self._parse_array('c', 16, length=1)[0])
+
+    def parse_nullable_int_array(
+        self,
+        fill_value: int = R_INT_NA,
+    ) -> npt.NDArray[np.int32] | np.ma.MaskedArray[Any, Any]:  # noqa: D102
+
+        data = self._parse_array('i', 4)
+        mask = data == R_INT_NA
+        data[mask] = fill_value
+
+        if np.any(mask):
+            return np.ma.array(  # type: ignore
+                data=data,
+                mask=mask,
+                fill_value=fill_value,
+            )
+
+        return data
+
+    def parse_double_array(self) -> npt.NDArray[np.float64]:  # noqa: D102
+        return self._parse_array('f', 8)
+
+    def parse_complex_array(self) -> npt.NDArray[np.complex128]:  # noqa: D102
+        return self._parse_array('c', 16)
+
+    def parse_string(self, length: int) -> bytes:  # noqa: D102
+        return self.file.read(length)
+
+    def parse_all(self) -> RData:
+        rdata = super().parse_all()
+        # Check that there is no more data in the file
+        assert self.file.read(1) == b''
+        return rdata

--- a/rdata/io/xdr.py
+++ b/rdata/io/xdr.py
@@ -37,27 +37,31 @@ class ParserXDR(Parser):
         )
         self.file = file
 
-    def _parse_array(self,
-                     dtype: np.dtype,
-                     *,
-                     length: int | None = None,
+    def _parse_array(
+            self,
+            dtype: np.dtype,
     ) -> npt.NDArray[Any]:  # noqa: D102
-        if length is None:
-            length = self.parse_int()
+        length = self.parse_int()
+        return self._parse_array_values(dtype, length)
 
+    def _parse_array_values(
+            self,
+            dtype: np.dtype,
+            length: int,
+    ) -> npt.NDArray[Any]:  # noqa: D102
         dtype = np.dtype(dtype)
         buffer = self.file.read(length * dtype.itemsize)
         # Read in big-endian order and convert to native byte order
         return np.frombuffer(buffer, dtype=dtype.newbyteorder('>')).astype(dtype, copy=False)
 
     def parse_int(self) -> int:  # noqa: D102
-        return int(self._parse_array(np.int32, length=1)[0])
+        return int(self._parse_array_values(np.int32, 1)[0])
 
     def parse_double(self) -> float:  # noqa: D102
-        return float(self._parse_array(np.float64, length=1)[0])
+        return float(self._parse_array_values(np.float64, 1)[0])
 
     def parse_complex(self) -> complex:  # noqa: D102
-        return complex(self._parse_array(np.complex128, length=1)[0])
+        return complex(self._parse_array_values(np.complex128, 1)[0])
 
     def parse_nullable_int_array(
         self,

--- a/rdata/parser/_parser.py
+++ b/rdata/parser/_parser.py
@@ -1248,7 +1248,7 @@ def parse_rdata_binary(
         data = data[len(format_dict[format_type]):]
 
     if format_type is RdataFormats.XDR:
-        from rdata.io.xdr import ParserXDR
+        from ._xdr import ParserXDR
 
         parser = ParserXDR(
             io.BytesIO(data),

--- a/rdata/parser/_parser.py
+++ b/rdata/parser/_parser.py
@@ -14,7 +14,6 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import (
     Any,
-    BinaryIO,
     Callable,
     Final,
     Mapping,
@@ -997,79 +996,6 @@ class Parser(abc.ABC):
         return result
 
 
-class ParserXDR(Parser):
-    """Parser used when the integers and doubles are in XDR format."""
-
-    def __init__(
-        self,
-        file: BinaryIO,
-        *,
-        expand_altrep: bool = True,
-        altrep_constructor_dict: AltRepConstructorMap = DEFAULT_ALTREP_MAP,
-    ) -> None:
-        super().__init__(
-            expand_altrep=expand_altrep,
-            altrep_constructor_dict=altrep_constructor_dict,
-        )
-        self.file = file
-
-    def _parse_array(self,
-                     itemkind: str,
-                     itemsize: int,
-                     *,
-                     length: int | None = None,
-    ) -> npt.NDArray[Any]:  # noqa: D102
-        if length is None:
-            length = self.parse_int()
-
-        itemtype = f'{itemkind}{itemsize}'
-        buffer = self.file.read(length * itemsize)
-        # Read in big-endian order and convert to native byte order
-        return np.frombuffer(buffer, dtype=f'>{itemtype}').astype(f'={itemtype}')
-
-    def parse_int(self) -> int:  # noqa: D102
-        return int(self._parse_array('i', 4, length=1)[0])
-
-    def parse_double(self) -> float:  # noqa: D102
-        return float(self._parse_array('f', 8, length=1)[0])
-
-    def parse_complex(self) -> complex:  # noqa: D102
-        return complex(self._parse_array('c', 16, length=1)[0])
-
-    def parse_nullable_int_array(
-        self,
-        fill_value: int = R_INT_NA,
-    ) -> npt.NDArray[np.int32] | np.ma.MaskedArray[Any, Any]:  # noqa: D102
-
-        data = self._parse_array('i', 4)
-        mask = data == R_INT_NA
-        data[mask] = fill_value
-
-        if np.any(mask):
-            return np.ma.array(  # type: ignore
-                data=data,
-                mask=mask,
-                fill_value=fill_value,
-            )
-
-        return data
-
-    def parse_double_array(self) -> npt.NDArray[np.float64]:  # noqa: D102
-        return self._parse_array('f', 8)
-
-    def parse_complex_array(self) -> npt.NDArray[np.complex128]:  # noqa: D102
-        return self._parse_array('c', 16)
-
-    def parse_string(self, length: int) -> bytes:  # noqa: D102
-        return self.file.read(length)
-
-    def parse_all(self) -> RData:
-        rdata = super().parse_all()
-        # Check that there is no more data in the file
-        assert self.file.read(1) == b''
-        return rdata
-
-
 def parse_file(
     file_or_path: AcceptableFile | os.PathLike[Any] | Traversable | str,
     *,
@@ -1322,6 +1248,8 @@ def parse_rdata_binary(
         data = data[len(format_dict[format_type]):]
 
     if format_type is RdataFormats.XDR:
+        from rdata.io.xdr import ParserXDR
+
         parser = ParserXDR(
             io.BytesIO(data),
             expand_altrep=expand_altrep,

--- a/rdata/parser/_parser.py
+++ b/rdata/parser/_parser.py
@@ -4,7 +4,6 @@ import abc
 import bz2
 import enum
 import gzip
-import io
 import lzma
 import os
 import pathlib
@@ -1251,7 +1250,7 @@ def parse_rdata_binary(
         from ._xdr import ParserXDR
 
         parser = ParserXDR(
-            io.BytesIO(data),
+            data,
             expand_altrep=expand_altrep,
             altrep_constructor_dict=altrep_constructor_dict,
         )

--- a/rdata/parser/_parser.py
+++ b/rdata/parser/_parser.py
@@ -1036,7 +1036,7 @@ class ParserXDR(Parser):
         return self._parse_array('f', 8, length=1)[0]
 
     def parse_complex(self) -> complex:  # noqa: D102
-        return self._parse_array('c', 8, length=1)[0]
+        return self._parse_array('c', 16, length=1)[0]
 
     def parse_nullable_int_array(
         self,
@@ -1060,7 +1060,7 @@ class ParserXDR(Parser):
         return self._parse_array('f', 8)
 
     def parse_complex_array(self) -> npt.NDArray[np.complex64]:
-        return self._parse_array('c', 8)
+        return self._parse_array('c', 16)
 
     def parse_string(self, length: int) -> bytes:  # noqa: D102
         result = self.data[self.position:(self.position + length)]

--- a/rdata/parser/_xdr.py
+++ b/rdata/parser/_xdr.py
@@ -14,7 +14,6 @@ from ._parser import (
     DEFAULT_ALTREP_MAP,
     Parser,
     RData,
-    R_INT_NA,
 )
 
 
@@ -34,57 +33,17 @@ class ParserXDR(Parser):
         )
         self.file = io.BytesIO(data)
 
-    def _parse_array(
-            self,
-            dtype: np.dtype,
-    ) -> npt.NDArray[Any]:  # noqa: D102
-        length = self.parse_int()
-        return self._parse_array_values(dtype, length)
-
     def _parse_array_values(
             self,
             dtype: np.dtype,
             length: int,
-    ) -> npt.NDArray[Any]:  # noqa: D102
+    ) -> npt.NDArray[Any]:
         dtype = np.dtype(dtype)
         buffer = self.file.read(length * dtype.itemsize)
         # Read in big-endian order and convert to native byte order
         return np.frombuffer(buffer, dtype=dtype.newbyteorder('>')).astype(dtype, copy=False)
 
-    def parse_int(self) -> int:  # noqa: D102
-        return int(self._parse_array_values(np.int32, 1)[0])
-
-    def parse_double(self) -> float:  # noqa: D102
-        return float(self._parse_array_values(np.float64, 1)[0])
-
-    def parse_complex(self) -> complex:  # noqa: D102
-        return complex(self._parse_array_values(np.complex128, 1)[0])
-
-    def parse_nullable_int_array(
-        self,
-        fill_value: int = R_INT_NA,
-    ) -> npt.NDArray[np.int32] | np.ma.MaskedArray[Any, Any]:  # noqa: D102
-
-        data = self._parse_array(np.int32)
-        mask = (data == R_INT_NA)
-        data[mask] = fill_value
-
-        if np.any(mask):
-            return np.ma.array(  # type: ignore
-                data=data,
-                mask=mask,
-                fill_value=fill_value,
-            )
-
-        return data
-
-    def parse_double_array(self) -> npt.NDArray[np.float64]:  # noqa: D102
-        return self._parse_array(np.float64)
-
-    def parse_complex_array(self) -> npt.NDArray[np.complex128]:  # noqa: D102
-        return self._parse_array(np.complex128)
-
-    def parse_string(self, length: int) -> bytes:  # noqa: D102
+    def parse_string(self, length: int) -> bytes:
         return self.file.read(length)
 
     def parse_all(self) -> RData:

--- a/rdata/parser/_xdr.py
+++ b/rdata/parser/_xdr.py
@@ -65,7 +65,7 @@ class ParserXDR(Parser):
     ) -> npt.NDArray[np.int32] | np.ma.MaskedArray[Any, Any]:  # noqa: D102
 
         data = self._parse_array(np.int32)
-        mask = data == R_INT_NA
+        mask = (data == R_INT_NA)
         data[mask] = fill_value
 
         if np.any(mask):

--- a/rdata/parser/_xdr.py
+++ b/rdata/parser/_xdr.py
@@ -13,12 +13,8 @@ from ._parser import (
     DEFAULT_ALTREP_MAP,
     Parser,
     RData,
+    R_INT_NA,
 )
-
-
-
-R_INT_NA = -2**31  # noqa: WPS432
-"""Value used to represent a missing integer in R."""
 
 
 class ParserXDR(Parser):

--- a/rdata/parser/_xdr.py
+++ b/rdata/parser/_xdr.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import io
+import numpy as np
+import numpy.typing as npt
 
 from typing import (
     Any,
 )
-
-import numpy as np
-import numpy.typing as npt
 
 from ._parser import (
     AltRepConstructorMap,
@@ -18,7 +17,7 @@ from ._parser import (
 
 
 class ParserXDR(Parser):
-    """Parser used when the integers and doubles are in XDR format."""
+    """Parser for data in XDR format."""
 
     def __init__(
         self,

--- a/rdata/parser/_xdr.py
+++ b/rdata/parser/_xdr.py
@@ -8,7 +8,7 @@ from typing import (
 import numpy as np
 import numpy.typing as npt
 
-from rdata.parser._parser import (
+from ._parser import (
     AltRepConstructorMap,
     DEFAULT_ALTREP_MAP,
     Parser,

--- a/rdata/parser/_xdr.py
+++ b/rdata/parser/_xdr.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import io
+
 from typing import (
     Any,
-    BinaryIO,
 )
 
 import numpy as np
@@ -22,7 +23,7 @@ class ParserXDR(Parser):
 
     def __init__(
         self,
-        file: BinaryIO,
+        data: memoryview,
         *,
         expand_altrep: bool = True,
         altrep_constructor_dict: AltRepConstructorMap = DEFAULT_ALTREP_MAP,
@@ -31,7 +32,7 @@ class ParserXDR(Parser):
             expand_altrep=expand_altrep,
             altrep_constructor_dict=altrep_constructor_dict,
         )
-        self.file = file
+        self.file = io.BytesIO(data)
 
     def _parse_array(
             self,


### PR DESCRIPTION
This PR adds faster reader for files in xdr format. Full arrays are read directly with numpy instead of reading element by element. As a positive side effect, deprecated xdrlib isn't needed anymore.

Related to #31. I have cherry-picked and rebased commits related to xdr reader improvements to this PR. There are also some structural changes that are open for discussion, for example, xdr reader is moved to `rdata/io/xdr.py` to simplify separation between different readers like (upcoming) `rdata/io/ascii.py`. @vnmabus Could you review?

