### PR TITLE
Bump minimum Python version to 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/examples/plot_cran.py
+++ b/examples/plot_cran.py
@@ -125,7 +125,7 @@ def graph_constructor(obj, attrs):
     return igraph.Graph(
         n=n_vertices,
         directed=is_directed,
-        edges=list(zip(edge_from, edge_to)),
+        edges=list(zip(edge_from, edge_to, strict=True)),
         graph_attrs=graph_attrs,
         vertex_attrs=vertex_attrs,
         edge_attrs=edge_attrs,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "rdata"
 description = "Read R datasets from Python."
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 license = {file = "LICENSE"}
 keywords = [
 	"rdata",

--- a/rdata/conversion/_conversion.py
+++ b/rdata/conversion/_conversion.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
 from fractions import Fraction
 from types import MappingProxyType, SimpleNamespace
-from typing import Any, Final, NamedTuple, Union, cast
+from typing import Any, Final, NamedTuple, TypeAlias, cast
 
 import numpy as np
 import pandas as pd
@@ -16,7 +16,7 @@ from typing_extensions import override
 
 from .. import parser
 
-ConversionFunction = Callable[[Union[parser.RData, parser.RObject]], Any]
+ConversionFunction: TypeAlias = Callable[[parser.RData | parser.RObject], Any]
 
 
 class RLanguage(NamedTuple):
@@ -172,7 +172,7 @@ def convert_attrs(
     """
     if r_obj.attributes:
         attrs = cast(
-            Mapping[str, Any],
+            "Mapping[str, Any]",
             conversion_function(r_obj.attributes),
         )
     else:
@@ -223,7 +223,7 @@ def convert_vector(
     # If it has the name attribute, use a dict instead
     field_names = attrs.get("names")
     if field_names is not None:
-        value = dict(zip(field_names, value))
+        value = dict(zip(field_names, value, strict=True))
 
     return value
 
@@ -490,8 +490,14 @@ def ts_constructor(
 
     frequency = int(frequency)
 
-    real_start = Fraction(int(round(start * frequency)), frequency)
-    real_end = Fraction(int(round(end * frequency)), frequency)
+    real_start = Fraction(
+        int(round(start * frequency)),  # noqa: RUF046
+        frequency,
+    )
+    real_end = Fraction(
+        int(round(end * frequency)),  # noqa: RUF046
+        frequency,
+    )
 
     index: np.ndarray[Any, Any] = np.arange(
         real_start,
@@ -578,9 +584,9 @@ def srcfilecopy_constructor(
     )
 
 
-Constructor = Callable[[Any, Mapping[str, Any]], Any]
-ConstructorDict = Mapping[
-    Union[str, bytes],
+Constructor: TypeAlias = Callable[[Any, Mapping[str, Any]], Any]
+ConstructorDict: TypeAlias = Mapping[
+    str | bytes,
     Constructor,
 ]
 
@@ -602,7 +608,10 @@ class Converter(abc.ABC):
     """Interface of a class converting R objects in Python objects."""
 
     @abc.abstractmethod
-    def convert(self, data: parser.RData | parser.RObject) -> Any:  # noqa: ANN401
+    def convert(
+        self,
+        data: parser.RData | parser.RObject,
+    ) -> Any:  # noqa: ANN401
         """Convert a R object to a Python one."""
 
 

--- a/rdata/parser/_parser.py
+++ b/rdata/parser/_parser.py
@@ -16,7 +16,6 @@ from typing import (
     Any,
     Final,
     Protocol,
-    Union,
     runtime_checkable,
 )
 
@@ -47,7 +46,7 @@ class BinaryBufferFileLike(Protocol):
         """Get the underlying buffer."""
 
 
-AcceptableFile = Union[BinaryFileLike, BinaryBufferFileLike]
+AcceptableFile = BinaryFileLike | BinaryBufferFileLike
 
 try:
     from importlib.resources.abc import Traversable as Traversable

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
## Describe the proposed changes

We drop support for Python 3.9 and Python 3.10, in compliance with the [SPEC 0](https://scientific-python.org/specs/spec-0000/) calendar.

In addition we test now in Python 3.13.

- [x] I have performed a self-review of my code
- [x] The code conforms to the style used in this package (checked with [Ruff](https://docs.astral.sh/ruff/))
- [x] The code is fully documented and typed (type-checked with [Mypy](https://mypy-lang.org/))
- [x] I have added thorough tests for the new/changed functionality
