### PR TITLE
Add support for binary non-XDR format

### DIFF
--- a/rdata/parser/_binary.py
+++ b/rdata/parser/_binary.py
@@ -8,6 +8,7 @@ import numpy.typing as npt
 
 from ._parser import AltRepConstructorMap, Parser
 
+_BYTEORDER_MARKER_SIZE = 4
 _SUPPORTED_FORMAT_VERSIONS = {2, 3}
 
 
@@ -30,11 +31,11 @@ class ParserBinary(Parser):
 
     @staticmethod
     def _detect_byteorder(data: memoryview) -> Literal["<", ">"]:
-        if len(data) < 4:
+        if len(data) < _BYTEORDER_MARKER_SIZE:
             msg = "Unknown binary endianness"
             raise NotImplementedError(msg)
 
-        first_int = bytes(data[:4])
+        first_int = bytes(data[:_BYTEORDER_MARKER_SIZE])
         little = int.from_bytes(first_int, byteorder="little", signed=True)
         big = int.from_bytes(first_int, byteorder="big", signed=True)
 

--- a/rdata/parser/_binary.py
+++ b/rdata/parser/_binary.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import io
+from typing import Any, Literal
+
+import numpy as np
+import numpy.typing as npt
+
+from ._parser import AltRepConstructorMap, Parser
+
+_SUPPORTED_FORMAT_VERSIONS = {2, 3}
+
+
+class ParserBinary(Parser):
+    """Parser for data in native binary format."""
+
+    def __init__(
+        self,
+        data: memoryview,
+        *,
+        expand_altrep: bool,
+        altrep_constructor_dict: AltRepConstructorMap,
+    ) -> None:
+        super().__init__(
+            expand_altrep=expand_altrep,
+            altrep_constructor_dict=altrep_constructor_dict,
+        )
+        self.file = io.BytesIO(data)
+        self.byteorder = self._detect_byteorder(data)
+
+    @staticmethod
+    def _detect_byteorder(data: memoryview) -> Literal["<", ">"]:
+        if len(data) < 4:
+            msg = "Unknown binary endianness"
+            raise NotImplementedError(msg)
+
+        first_int = bytes(data[:4])
+        little = int.from_bytes(first_int, byteorder="little", signed=True)
+        big = int.from_bytes(first_int, byteorder="big", signed=True)
+
+        little_is_valid = little in _SUPPORTED_FORMAT_VERSIONS
+        big_is_valid = big in _SUPPORTED_FORMAT_VERSIONS
+
+        if little_is_valid and not big_is_valid:
+            return "<"
+        if big_is_valid and not little_is_valid:
+            return ">"
+
+        msg = "Unknown binary endianness"
+        raise NotImplementedError(msg)
+
+    def _parse_array_values(
+        self,
+        dtype: npt.DTypeLike,
+        length: int,
+    ) -> npt.NDArray[Any]:
+        dtype = np.dtype(dtype)
+        buffer = self.file.read(length * dtype.itemsize)
+        return np.frombuffer(
+            buffer,
+            dtype=dtype.newbyteorder(self.byteorder),
+        ).astype(dtype, copy=False)
+
+    def parse_string(self, length: int) -> bytes:
+        return self.file.read(length)
+
+    def check_complete(self) -> None:
+        assert self.file.read(1) == b""

--- a/rdata/parser/_binary.py
+++ b/rdata/parser/_binary.py
@@ -56,10 +56,12 @@ class ParserBinary(Parser):
     ) -> npt.NDArray[Any]:
         dtype = np.dtype(dtype)
         buffer = self.file.read(length * dtype.itemsize)
+        # `frombuffer` on bytes creates a read-only view.
+        # `mask_na_values` mutates integer arrays in place, so we need a copy.
         return np.frombuffer(
             buffer,
             dtype=dtype.newbyteorder(self.byteorder),
-        ).astype(dtype, copy=False)
+        ).astype(dtype, copy=True)
 
     def parse_string(self, length: int) -> bytes:
         return self.file.read(length)

--- a/rdata/parser/_parser.py
+++ b/rdata/parser/_parser.py
@@ -26,6 +26,7 @@ from rdata.missing import R_INT_NA, mask_na_values
 
 if TYPE_CHECKING:
     from ._ascii import ParserASCII
+    from ._binary import ParserBinary
     from ._xdr import ParserXDR
 
 
@@ -101,6 +102,8 @@ class FileTypes(enum.Enum):
     xz = "xz"
     rdata_binary_v2 = "rdata version 2 (binary)"
     rdata_binary_v3 = "rdata version 3 (binary)"
+    rdata_native_binary_v2 = "rdata version 2 (native binary)"
+    rdata_native_binary_v3 = "rdata version 3 (native binary)"
     rdata_ascii_v2 = "rdata version 2 (ascii)"
     rdata_ascii_v3 = "rdata version 3 (ascii)"
 
@@ -111,6 +114,8 @@ magic_dict = {
     FileTypes.xz: b"\xFD7zXZ\x00",
     FileTypes.rdata_binary_v2: b"RDX2\n",
     FileTypes.rdata_binary_v3: b"RDX3\n",
+    FileTypes.rdata_native_binary_v2: b"RDB2\n",
+    FileTypes.rdata_native_binary_v3: b"RDB3\n",
     FileTypes.rdata_ascii_v2: b"RDA2\n",
     FileTypes.rdata_ascii_v3: b"RDA3\n",
 }
@@ -1218,6 +1223,8 @@ type=<RObjectType.CHAR: 9>,
         if filetype in {
             FileTypes.rdata_binary_v2,
             FileTypes.rdata_binary_v3,
+            FileTypes.rdata_native_binary_v2,
+            FileTypes.rdata_native_binary_v3,
             FileTypes.rdata_ascii_v2,
             FileTypes.rdata_ascii_v3,
             None,
@@ -1232,6 +1239,8 @@ type=<RObjectType.CHAR: 9>,
         new_data = lzma.decompress(data)
     elif filetype in {FileTypes.rdata_binary_v2,
                       FileTypes.rdata_binary_v3,
+                      FileTypes.rdata_native_binary_v2,
+                      FileTypes.rdata_native_binary_v3,
                       FileTypes.rdata_ascii_v2,
                       FileTypes.rdata_ascii_v3,
                       }:
@@ -1273,7 +1282,7 @@ def parse_rdata_binary(
     if format_type:
         data = data[len(format_dict[format_type]):]
 
-    parser_class: type[ParserXDR | ParserASCII]
+    parser_class: type[ParserXDR | ParserASCII | ParserBinary]
 
     if format_type is RdataFormats.XDR:
         from ._xdr import ParserXDR  # noqa: PLC0415
@@ -1281,6 +1290,9 @@ def parse_rdata_binary(
     elif format_type in (RdataFormats.ASCII, RdataFormats.ASCII_CRLF):
         from ._ascii import ParserASCII  # noqa: PLC0415
         parser_class = ParserASCII
+    elif format_type is RdataFormats.binary:
+        from ._binary import ParserBinary  # noqa: PLC0415
+        parser_class = ParserBinary
     else:
         msg = "Unknown file format"
         raise NotImplementedError(msg)

--- a/rdata/parser/_xdr.py
+++ b/rdata/parser/_xdr.py
@@ -33,10 +33,13 @@ class ParserXDR(Parser):
         dtype = np.dtype(dtype)
         buffer = self.file.read(length * dtype.itemsize)
         # Read in big-endian order and convert to native byte order
+        # `frombuffer` on bytes creates a read-only view.
+        # On big-endian hosts conversion can be a no-op, so force a copy
+        # to keep arrays writable for downstream NA masking logic.
         return np.frombuffer(
             buffer,
             dtype=dtype.newbyteorder(">"),
-        ).astype(dtype, copy=False)
+        ).astype(dtype, copy=True)
 
     def parse_string(self, length: int) -> bytes:
         return self.file.read(length)

--- a/rdata/tests/test_rdata.py
+++ b/rdata/tests/test_rdata.py
@@ -1030,6 +1030,27 @@ class SimpleTests(unittest.TestCase):
         assert parsed.versions.format == 2
         assert parsed.object.info.type == rdata.parser.RObjectType.NILVALUE
 
+    def test_native_binary_rds_int_na(self) -> None:
+        """Test parsing native binary RDS integer vector containing NA."""
+        def i32(value: int) -> bytes:
+            return int(value).to_bytes(4, byteorder="little", signed=True)
+
+        data = b"".join((
+            b"B\n",
+            i32(2),
+            i32(0x00030002),
+            i32(0x00020300),
+            i32(13),  # INT object type
+            i32(1),   # vector length
+            i32(-2**31),  # R integer NA sentinel
+        ))
+        parsed = rdata.parser.parse_data(data, extension=".rds")
+
+        assert parsed.object.info.type == rdata.parser.RObjectType.INT
+        value = parsed.object.value
+        assert np.ma.isMaskedArray(value)  # type: ignore[no-untyped-call]
+        np.testing.assert_array_equal(value.mask, np.array([True]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/rdata/tests/test_rdata.py
+++ b/rdata/tests/test_rdata.py
@@ -978,6 +978,58 @@ class SimpleTests(unittest.TestCase):
         data = rdata.read_rds(TESTDATA_PATH / "test_ascii_nan_inf.rds")
         np.testing.assert_equal(data, [0., np.nan, np.inf, -np.inf])
 
+    def test_native_binary_rds_little_endian(self) -> None:
+        """Test parsing native binary RDS in little-endian byte order."""
+        def i32(value: int) -> bytes:
+            return int(value).to_bytes(4, byteorder="little", signed=True)
+
+        data = b"".join((
+            b"B\n",
+            i32(2),
+            i32(0x00030002),
+            i32(0x00020300),
+            i32(254),
+        ))
+        parsed = rdata.parser.parse_data(data, extension=".rds")
+
+        assert parsed.versions.format == 2
+        assert parsed.object.info.type == rdata.parser.RObjectType.NILVALUE
+
+    def test_native_binary_rds_big_endian(self) -> None:
+        """Test parsing native binary RDS in big-endian byte order."""
+        def i32(value: int) -> bytes:
+            return int(value).to_bytes(4, byteorder="big", signed=True)
+
+        data = b"".join((
+            b"B\n",
+            i32(2),
+            i32(0x00030002),
+            i32(0x00020300),
+            i32(254),
+        ))
+        parsed = rdata.parser.parse_data(data, extension=".rds")
+
+        assert parsed.versions.format == 2
+        assert parsed.object.info.type == rdata.parser.RObjectType.NILVALUE
+
+    def test_native_binary_rda_header(self) -> None:
+        """Test parsing native binary RDA with RDB wrapper magic."""
+        def i32(value: int) -> bytes:
+            return int(value).to_bytes(4, byteorder="little", signed=True)
+
+        data = b"".join((
+            b"RDB2\n",
+            b"B\n",
+            i32(2),
+            i32(0x00030002),
+            i32(0x00020300),
+            i32(254),
+        ))
+        parsed = rdata.parser.parse_data(data, extension=".rda")
+
+        assert parsed.versions.format == 2
+        assert parsed.object.info.type == rdata.parser.RObjectType.NILVALUE
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/rdata/tests/test_rdata.py
+++ b/rdata/tests/test_rdata.py
@@ -16,6 +16,7 @@ import rdata
 from rdata.missing import R_FLOAT_NA
 
 TESTDATA_PATH = rdata.TESTDATA_PATH
+NATIVE_BINARY_FORMAT_VERSION = 2
 
 
 class SimpleTests(unittest.TestCase):
@@ -992,7 +993,7 @@ class SimpleTests(unittest.TestCase):
         ))
         parsed = rdata.parser.parse_data(data, extension=".rds")
 
-        assert parsed.versions.format == 2
+        assert parsed.versions.format == NATIVE_BINARY_FORMAT_VERSION
         assert parsed.object.info.type == rdata.parser.RObjectType.NILVALUE
 
     def test_native_binary_rds_big_endian(self) -> None:
@@ -1009,7 +1010,7 @@ class SimpleTests(unittest.TestCase):
         ))
         parsed = rdata.parser.parse_data(data, extension=".rds")
 
-        assert parsed.versions.format == 2
+        assert parsed.versions.format == NATIVE_BINARY_FORMAT_VERSION
         assert parsed.object.info.type == rdata.parser.RObjectType.NILVALUE
 
     def test_native_binary_rda_header(self) -> None:
@@ -1027,7 +1028,7 @@ class SimpleTests(unittest.TestCase):
         ))
         parsed = rdata.parser.parse_data(data, extension=".rda")
 
-        assert parsed.versions.format == 2
+        assert parsed.versions.format == NATIVE_BINARY_FORMAT_VERSION
         assert parsed.object.info.type == rdata.parser.RObjectType.NILVALUE
 
     def test_native_binary_rds_int_na(self) -> None:

--- a/rdata/tests/test_write.py
+++ b/rdata/tests/test_write.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 TESTDATA_PATH = rdata.TESTDATA_PATH
 
 valid_compressions = [None, "bzip2", "gzip", "xz"]
-valid_formats = ["xdr", "ascii"]
+valid_formats = ["xdr", "ascii", "binary"]
 
 
 def decompress_data(data: bytes) -> bytes:
@@ -65,6 +65,8 @@ def parse_file_type_and_format(data: bytes) -> tuple[FileType, FileFormat]:
     if filetype in {
             FileTypes.rdata_binary_v2,
             FileTypes.rdata_binary_v3,
+            FileTypes.rdata_native_binary_v2,
+            FileTypes.rdata_native_binary_v3,
             FileTypes.rdata_ascii_v2,
             FileTypes.rdata_ascii_v3,
             }:
@@ -75,7 +77,15 @@ def parse_file_type_and_format(data: bytes) -> tuple[FileType, FileFormat]:
         file_type_str = "rds"
 
     rdataformat = rdata_format(view)
-    file_format_str = "xdr" if rdataformat is RdataFormats.XDR else "ascii"
+    if rdataformat is RdataFormats.XDR:
+        file_format_str = "xdr"
+    elif rdataformat in (RdataFormats.ASCII, RdataFormats.ASCII_CRLF):
+        file_format_str = "ascii"
+    elif rdataformat is RdataFormats.binary:
+        file_format_str = "binary"
+    else:
+        msg = "Unknown file format"
+        raise ValueError(msg)
 
     return file_type_str, file_format_str
 
@@ -236,6 +246,27 @@ def test_unparse_big_int(file_format: FileFormat, value: int) -> None:
     r_data = converter.convert_to_r_data(value)
     with pytest.raises(ValueError, match="(?i)not castable"):
         unparse_data(r_data, file_format=file_format)
+
+
+def test_unparse_binary_magic_rds() -> None:
+    """Test writing native binary RDS magic."""
+    converter = ConverterFromPythonToR()
+    r_data = converter.convert_to_r_data([1, 2, 3])
+
+    out_data = unparse_data(r_data, file_format="binary", file_type="rds")
+
+    assert out_data[:2] == b"B\n"
+
+
+def test_unparse_binary_magic_rda() -> None:
+    """Test writing native binary RDA magic."""
+    converter = ConverterFromPythonToR()
+    r_data = converter.convert_to_r_data({"x": [1]}, file_type="rda")
+
+    out_data = unparse_data(r_data, file_format="binary", file_type="rda")
+
+    assert out_data.startswith(b"RDB")
+    assert out_data[5:7] == b"B\n"
 
 
 def test_convert_dataframe_pandas_dtypes() -> None:

--- a/rdata/unparser/__init__.py
+++ b/rdata/unparser/__init__.py
@@ -11,6 +11,7 @@ from rdata.parser import (
 )
 
 from ._ascii import UnparserASCII
+from ._binary import UnparserBinary
 from ._xdr import UnparserXDR
 
 if TYPE_CHECKING:
@@ -20,7 +21,7 @@ if TYPE_CHECKING:
 
     from ._unparser import WriteableBinaryFile
 
-    FileFormat = Literal["xdr", "ascii"]
+    FileFormat = Literal["xdr", "ascii", "binary"]
     FileType = Literal["rds", "rda"]
     Compression = Literal["gzip", "bzip2", "xz", None]
 
@@ -84,7 +85,7 @@ def unparse_fileobj(
         file_format: File format.
         file_type: File type.
     """
-    unparser_class: type[UnparserXDR | UnparserASCII]
+    unparser_class: type[UnparserXDR | UnparserASCII | UnparserBinary]
 
     if file_format == "ascii":
         unparser_class = UnparserASCII
@@ -94,6 +95,10 @@ def unparse_fileobj(
         unparser_class = UnparserXDR
 
         rda_magic = "RDX"
+    elif file_format == "binary":
+        unparser_class = UnparserBinary
+
+        rda_magic = "RDB"
     else:
         msg = f"Unknown file format: {file_format}"
         raise ValueError(msg)

--- a/rdata/unparser/_binary.py
+++ b/rdata/unparser/_binary.py
@@ -1,0 +1,40 @@
+"""Unparser for files in native binary format."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from ._unparser import Unparser, WriteableBinaryFile
+
+if TYPE_CHECKING:
+    import numpy.typing as npt
+
+
+class UnparserBinary(Unparser):
+    """Unparser for files in native binary format."""
+
+    def __init__(
+        self,
+        file: WriteableBinaryFile,
+    ) -> None:
+        """Unparser for files in native binary format."""
+        self.file = file
+
+    def unparse_magic(self) -> None:
+        """Unparse magic bits."""
+        self.file.write(b"B\n")
+
+    def _unparse_array_values_raw(
+        self,
+        array: npt.NDArray[np.int32 | np.float64 | np.complex128],
+    ) -> None:
+        # R native binary serialization stores data in host byte order.
+        native_array = np.ascontiguousarray(
+            array.astype(array.dtype.newbyteorder("="), copy=False),
+        )
+        self.file.write(native_array.tobytes())
+
+    def _unparse_string_characters(self, value: bytes) -> None:
+        self.file.write(value)


### PR DESCRIPTION
## References to issues or other PRs
N/A


## Describe the proposed changes
- Add native binary read/write support alongside existing XDR and ASCII support.
- Update tests to cover native-binary parsing and writing paths.
- Minor bug fix: on big-endian systems, XDR parser would try to write to a read-only buffer to fill NAs (gets implicitly copied/writable on little endian systems)

## Additional information
Round trip example
```r
obj <- list(
  data.frame(id = c(1L, 2L), value = c("a", "b")),
  "hello"
)
con <- file("native_in.rds", "wb")
serialize(obj, con, ascii = FALSE, xdr = FALSE, version = 3)
close(con)
```

```python
import rdata

py_obj = rdata.read_rds("native_in.rds")
rdata.write_rds("native_out.rds", py_obj, file_format="binary", compression=None)

with open("native_out.rds", "rb") as f:
    assert f.read(2) == b"B\n"
```

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] The code conforms to the style used in this package (checked with [Ruff](https://docs.astral.sh/ruff/)) 
-- (pre-existing lint errors)
- [x] The code is fully documented and typed (type-checked with [Mypy](https://mypy-lang.org/))
- [x] I have added thorough tests for the new/changed functionality
